### PR TITLE
Refactor Bomb life time code and remove the need for _ready call

### DIFF
--- a/godot/actors/weapons/Bomb.tscn
+++ b/godot/actors/weapons/Bomb.tscn
@@ -36,6 +36,7 @@ script = ExtResource( 1 )
 
 [node name="Trail2D" type="Line2D" parent="."]
 modulate = Color( 1, 1, 1, 0.313726 )
+points = PoolVector2Array( -1, -2 )
 width = 15.0
 default_color = Color( 1, 1, 1, 1 )
 texture_mode = 2699552
@@ -135,8 +136,13 @@ bus = "SFX"
 [node name="sound" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 14 )
 volume_db = 10.0
+autoplay = true
 bus = "SFX"
 area_mask = 8
 
+[node name="LifeTime" type="Timer" parent="."]
+wait_time = 1.5
+one_shot = true
 [connection signal="area_entered" from="NearArea" to="." method="_on_NearArea_area_entered"]
 [connection signal="area_exited" from="NearArea" to="." method="_on_NearArea_area_exited"]
+[connection signal="timeout" from="LifeTime" to="." method="_on_LifeTime_timeout"]


### PR DESCRIPTION
Hey there, I was reading some of the content in the repo, and I faced this snippet of code. So I decided to try to make it simpler.

Basically I refactored the logic inside the `_ready` and the logic behind the Bomb life spam. I dunno if it actually reflects the previous logic, but as far as my brain can tell it stays the same, but inside a signal callback and an specialized function. So if changes must be made they will be inside the scope of this function instead of the `_physics_process` which is a callback and if inherited by children classes will call the parent's implementation as well, so is a good practice to have the `_physics_process` calling other methods instead of having its own behavior :nerd_face: 

If you don't quite like these modifications, is all good to close the PR without merge! :wink: :pig: 