### PR TITLE
Don't override the locale on startup

### DIFF
--- a/godot/special_scenes/title_screen/TitleScreen.gd
+++ b/godot/special_scenes/title_screen/TitleScreen.gd
@@ -10,7 +10,6 @@ onready var animation = $Animator
 var can_press = false
 
 func initialize():
-	TranslationServer.set_locale(OS.get_locale())
 	animation.stop(true)
 	animation.play("fade_in")
 	yield(animation, "animation_finished")


### PR DESCRIPTION
This makes it possible to specify the locale by hand using the `--language` command-line argument, which is useful for testing.

Godot will still use the system locale by default, as long as a localization file is available. (See the [source code](https://github.com/godotengine/godot/blob/7f3490c5e118b10f444edd8e7e8cdbc85df84085/core/translation.cpp#L1144-L1150) for details.)