### PR TITLE
feat: Remove starting powerups

### DIFF
--- a/godot/combat/levels/sets/combat/first_blood/2players.tscn
+++ b/godot/combat/levels/sets/combat/first_blood/2players.tscn
@@ -158,31 +158,23 @@ type = "shields"
 position = Vector2( -1697.06, -989.949 )
 type = "shields"
 
-[node name="PowerUp4" parent="Battlefield/Foreground" index="3" instance=ExtResource( 3 )]
-position = Vector2( -1979.9, -989.949 )
-type = "miniball_gun"
-
-[node name="PowerUp9" parent="Battlefield/Foreground" index="4" instance=ExtResource( 3 )]
-position = Vector2( 1979.9, 989.949 )
-type = "miniball_gun"
-
-[node name="PowerUp10" parent="Battlefield/Foreground" index="5" instance=ExtResource( 3 )]
+[node name="PowerUp10" parent="Battlefield/Foreground" index="3" instance=ExtResource( 3 )]
 position = Vector2( 848.528, 989.949 )
 type = "shields"
 
-[node name="PowerUp19" parent="Battlefield/Foreground" index="6" instance=ExtResource( 3 )]
+[node name="PowerUp19" parent="Battlefield/Foreground" index="4" instance=ExtResource( 3 )]
 position = Vector2( 1131.37, 989.949 )
 type = "shields"
 
-[node name="PowerUp20" parent="Battlefield/Foreground" index="7" instance=ExtResource( 3 )]
+[node name="PowerUp20" parent="Battlefield/Foreground" index="5" instance=ExtResource( 3 )]
 position = Vector2( 1697.06, 989.949 )
 type = "shields"
 
-[node name="PowerUp11" parent="Battlefield/Foreground" index="8" instance=ExtResource( 3 )]
+[node name="PowerUp11" parent="Battlefield/Foreground" index="6" instance=ExtResource( 3 )]
 position = Vector2( 1414.21, 989.95 )
 type = "shields"
 
-[node name="PowerUp3" parent="Battlefield/Foreground" index="9" instance=ExtResource( 3 )]
+[node name="PowerUp3" parent="Battlefield/Foreground" index="7" instance=ExtResource( 3 )]
 position = Vector2( -848.528, -989.949 )
 type = "shields"
 

--- a/godot/combat/levels/sets/combat/first_blood/3players.tscn
+++ b/godot/combat/levels/sets/combat/first_blood/3players.tscn
@@ -169,51 +169,39 @@ type = "shields"
 position = Vector2( -1697.06, -989.949 )
 type = "shields"
 
-[node name="PowerUp4" parent="Battlefield/Foreground" index="3" instance=ExtResource( 4 )]
-position = Vector2( -1979.9, -989.949 )
-type = "miniball_gun"
-
-[node name="PowerUp8" parent="Battlefield/Foreground" index="4" instance=ExtResource( 4 )]
-position = Vector2( 1979.9, -989.949 )
-type = "miniball_gun"
-
-[node name="PowerUp9" parent="Battlefield/Foreground" index="5" instance=ExtResource( 4 )]
-position = Vector2( 1979.9, 989.949 )
-type = "miniball_gun"
-
-[node name="PowerUp10" parent="Battlefield/Foreground" index="6" instance=ExtResource( 4 )]
+[node name="PowerUp10" parent="Battlefield/Foreground" index="3" instance=ExtResource( 4 )]
 position = Vector2( 848.528, 989.949 )
 type = "shields"
 
-[node name="PowerUp19" parent="Battlefield/Foreground" index="7" instance=ExtResource( 4 )]
+[node name="PowerUp19" parent="Battlefield/Foreground" index="4" instance=ExtResource( 4 )]
 position = Vector2( 1131.37, 989.949 )
 type = "shields"
 
-[node name="PowerUp20" parent="Battlefield/Foreground" index="8" instance=ExtResource( 4 )]
+[node name="PowerUp20" parent="Battlefield/Foreground" index="5" instance=ExtResource( 4 )]
 position = Vector2( 1697.06, 989.949 )
 type = "shields"
 
-[node name="PowerUp11" parent="Battlefield/Foreground" index="9" instance=ExtResource( 4 )]
+[node name="PowerUp11" parent="Battlefield/Foreground" index="6" instance=ExtResource( 4 )]
 position = Vector2( 1414.21, 989.95 )
 type = "shields"
 
-[node name="PowerUp12" parent="Battlefield/Foreground" index="10" instance=ExtResource( 4 )]
+[node name="PowerUp12" parent="Battlefield/Foreground" index="7" instance=ExtResource( 4 )]
 position = Vector2( 848.528, -989.949 )
 type = "shields"
 
-[node name="PowerUp17" parent="Battlefield/Foreground" index="11" instance=ExtResource( 4 )]
+[node name="PowerUp17" parent="Battlefield/Foreground" index="8" instance=ExtResource( 4 )]
 position = Vector2( 1131.37, -989.949 )
 type = "shields"
 
-[node name="PowerUp18" parent="Battlefield/Foreground" index="12" instance=ExtResource( 4 )]
+[node name="PowerUp18" parent="Battlefield/Foreground" index="9" instance=ExtResource( 4 )]
 position = Vector2( 1697.06, -989.949 )
 type = "shields"
 
-[node name="PowerUp13" parent="Battlefield/Foreground" index="13" instance=ExtResource( 4 )]
+[node name="PowerUp13" parent="Battlefield/Foreground" index="10" instance=ExtResource( 4 )]
 position = Vector2( 1414.21, -989.95 )
 type = "shields"
 
-[node name="PowerUp3" parent="Battlefield/Foreground" index="14" instance=ExtResource( 4 )]
+[node name="PowerUp3" parent="Battlefield/Foreground" index="11" instance=ExtResource( 4 )]
 position = Vector2( -848.528, -989.949 )
 type = "shields"
 

--- a/godot/combat/levels/sets/combat/first_blood/4players.tscn
+++ b/godot/combat/levels/sets/combat/first_blood/4players.tscn
@@ -196,55 +196,39 @@ type = "shields"
 position = Vector2( -848.528, 989.949 )
 type = "shields"
 
-[node name="PowerUp4" parent="Battlefield/Foreground" index="7" instance=ExtResource( 4 )]
-position = Vector2( -1979.9, -989.949 )
-type = "miniball_gun"
-
-[node name="PowerUp8" parent="Battlefield/Foreground" index="8" instance=ExtResource( 4 )]
-position = Vector2( 1979.9, -989.949 )
-type = "miniball_gun"
-
-[node name="PowerUp9" parent="Battlefield/Foreground" index="9" instance=ExtResource( 4 )]
-position = Vector2( 1979.9, 989.949 )
-type = "miniball_gun"
-
-[node name="PowerUp10" parent="Battlefield/Foreground" index="10" instance=ExtResource( 4 )]
+[node name="PowerUp10" parent="Battlefield/Foreground" index="7" instance=ExtResource( 4 )]
 position = Vector2( 848.528, 989.949 )
 type = "shields"
 
-[node name="PowerUp19" parent="Battlefield/Foreground" index="11" instance=ExtResource( 4 )]
+[node name="PowerUp19" parent="Battlefield/Foreground" index="8" instance=ExtResource( 4 )]
 position = Vector2( 1131.37, 989.949 )
 type = "shields"
 
-[node name="PowerUp20" parent="Battlefield/Foreground" index="12" instance=ExtResource( 4 )]
+[node name="PowerUp20" parent="Battlefield/Foreground" index="9" instance=ExtResource( 4 )]
 position = Vector2( 1697.06, 989.949 )
 type = "shields"
 
-[node name="PowerUp11" parent="Battlefield/Foreground" index="13" instance=ExtResource( 4 )]
+[node name="PowerUp11" parent="Battlefield/Foreground" index="10" instance=ExtResource( 4 )]
 position = Vector2( 1414.21, 989.95 )
 type = "shields"
 
-[node name="PowerUp12" parent="Battlefield/Foreground" index="14" instance=ExtResource( 4 )]
+[node name="PowerUp12" parent="Battlefield/Foreground" index="11" instance=ExtResource( 4 )]
 position = Vector2( 848.528, -989.949 )
 type = "shields"
 
-[node name="PowerUp17" parent="Battlefield/Foreground" index="15" instance=ExtResource( 4 )]
+[node name="PowerUp17" parent="Battlefield/Foreground" index="12" instance=ExtResource( 4 )]
 position = Vector2( 1131.37, -989.949 )
 type = "shields"
 
-[node name="PowerUp18" parent="Battlefield/Foreground" index="16" instance=ExtResource( 4 )]
+[node name="PowerUp18" parent="Battlefield/Foreground" index="13" instance=ExtResource( 4 )]
 position = Vector2( 1697.06, -989.949 )
 type = "shields"
 
-[node name="PowerUp13" parent="Battlefield/Foreground" index="17" instance=ExtResource( 4 )]
+[node name="PowerUp13" parent="Battlefield/Foreground" index="14" instance=ExtResource( 4 )]
 position = Vector2( 1414.21, -989.95 )
 type = "shields"
 
-[node name="PowerUp7" parent="Battlefield/Foreground" index="18" instance=ExtResource( 4 )]
-position = Vector2( -1979.9, 989.949 )
-type = "miniball_gun"
-
-[node name="PowerUp3" parent="Battlefield/Foreground" index="19" instance=ExtResource( 4 )]
+[node name="PowerUp3" parent="Battlefield/Foreground" index="15" instance=ExtResource( 4 )]
 position = Vector2( -848.528, -989.949 )
 type = "shields"
 

--- a/godot/combat/levels/sets/combat/nine_lives/2players.tscn
+++ b/godot/combat/levels/sets/combat/nine_lives/2players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://combat/levels/sets/combat/nine_lives/Variants.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/geometry/GBeveledRect.gd" type="Script" id=2]
@@ -12,7 +12,6 @@
 [ext_resource path="res://actors/environments/Wall.tscn" type="PackedScene" id=10]
 [ext_resource path="res://combat/Arena.tscn" type="PackedScene" id=11]
 [ext_resource path="res://combat/levels/sets/combat/nine_lives/DontDieManager.tscn" type="PackedScene" id=13]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=14]
 [ext_resource path="res://addons/geometry/GConvexPolygon.gd" type="Script" id=16]
 
 [node name="Arena" instance=ExtResource( 11 )]
@@ -60,7 +59,6 @@ polygon = PoolVector2Array( 200, -600, 200, 0, -400, 0 )
 
 [node name="OutsideWall" parent="Battlefield/Background" index="3" instance=ExtResource( 10 )]
 hollow = true
-offset = 800
 hide_grid = true
 solid_line_color = Color( 1.1, 1, 1, 1 )
 grid_color = Color( 0, 1, 0.741176, 0.435294 )
@@ -94,14 +92,6 @@ begin_cap_mode = 2
 end_cap_mode = 2
 
 [node name="Variants" parent="Battlefield/Middleground" index="0" instance=ExtResource( 1 )]
-
-[node name="PowerUp" parent="Battlefield/Foreground" index="0" instance=ExtResource( 14 )]
-position = Vector2( -1500, 750 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Foreground" index="1" instance=ExtResource( 14 )]
-position = Vector2( 1500, -750 )
-type = "rocket_gun"
 
 [node name="p1" parent="SpawnPositions/Players" index="0" instance=ExtResource( 9 )]
 position = Vector2( -1500, 750 )

--- a/godot/combat/levels/sets/combat/nine_lives/3players.tscn
+++ b/godot/combat/levels/sets/combat/nine_lives/3players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://combat/levels/sets/combat/nine_lives/Variants.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/geometry/GBeveledRect.gd" type="Script" id=2]
@@ -12,7 +12,6 @@
 [ext_resource path="res://actors/environments/Wall.tscn" type="PackedScene" id=10]
 [ext_resource path="res://combat/Arena.tscn" type="PackedScene" id=11]
 [ext_resource path="res://combat/levels/sets/combat/nine_lives/DontDieManager.tscn" type="PackedScene" id=13]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=14]
 [ext_resource path="res://selection/characters/trixens_1.tres" type="Resource" id=15]
 [ext_resource path="res://addons/geometry/GConvexPolygon.gd" type="Script" id=16]
 
@@ -31,7 +30,6 @@ centered = false
 
 [node name="OutsideWall" parent="Battlefield/Background" index="1" instance=ExtResource( 10 )]
 hollow = true
-offset = 800
 hide_grid = true
 solid_line_color = Color( 1.1, 1, 1, 1 )
 grid_color = Color( 0, 1, 0.741176, 0.435294 )
@@ -96,18 +94,6 @@ end_cap_mode = 2
 
 [node name="Variants" parent="Battlefield/Middleground" index="0" instance=ExtResource( 1 )]
 
-[node name="PowerUp" parent="Battlefield/Foreground" index="0" instance=ExtResource( 14 )]
-position = Vector2( -1588, 750 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Foreground" index="1" instance=ExtResource( 14 )]
-position = Vector2( 1600, -750 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Foreground" index="2" instance=ExtResource( 14 )]
-position = Vector2( -1588, -750 )
-type = "rocket_gun"
-
 [node name="p1" parent="SpawnPositions/Players" index="0" instance=ExtResource( 9 )]
 position = Vector2( -1588, 750 )
 rotation = 0.0
@@ -125,10 +111,8 @@ rotation = 0.0
 controls = "joy2"
 species = ExtResource( 15 )
 
-[node name="Camera" parent="." index="6"]
+[node name="Camera" parent="." index="7"]
 zoom = Vector2( 62.5, 62.5 )
 smoothing_speed = 0.3
 
 [connection signal="item_rect_changed" from="BackgroundLayer/mantiacs_background" to="." method="_on_mantiacs_background_item_rect_changed"]
-
-[editable path="CanvasLayer/Pause"]

--- a/godot/combat/levels/sets/combat/nine_lives/4players.tscn
+++ b/godot/combat/levels/sets/combat/nine_lives/4players.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=17 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://combat/levels/sets/combat/nine_lives/Variants.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/geometry/GBeveledRect.gd" type="Script" id=2]
 [ext_resource path="res://addons/geometry/icons/GBeveledRect.svg" type="Texture" id=3]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=4]
 [ext_resource path="res://assets/patterns/xgrid.png" type="Texture" id=5]
 [ext_resource path="res://actors/environments/Wall.tscn" type="PackedScene" id=6]
 [ext_resource path="res://combat/Arena.tscn" type="PackedScene" id=7]
@@ -32,7 +31,6 @@ centered = false
 
 [node name="OutsideWall" parent="Battlefield/Background" index="1" instance=ExtResource( 6 )]
 hollow = true
-offset = 800
 hide_grid = true
 solid_line_color = Color( 1.1, 1, 1, 1 )
 grid_color = Color( 0, 1, 0.741176, 0.435294 )
@@ -97,22 +95,6 @@ end_cap_mode = 2
 
 [node name="Variants" parent="Battlefield/Middleground" index="0" instance=ExtResource( 1 )]
 
-[node name="PowerUp" parent="Battlefield/Foreground" index="0" instance=ExtResource( 4 )]
-position = Vector2( -1700, 750 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Foreground" index="1" instance=ExtResource( 4 )]
-position = Vector2( 1700, -750 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Foreground" index="2" instance=ExtResource( 4 )]
-position = Vector2( -1700, -750 )
-type = "rocket_gun"
-
-[node name="PowerUp4" parent="Battlefield/Foreground" index="3" instance=ExtResource( 4 )]
-position = Vector2( 1700, 750 )
-type = "rocket_gun"
-
 [node name="p1" parent="SpawnPositions/Players" index="0" instance=ExtResource( 8 )]
 position = Vector2( -1700, 750 )
 rotation = 0.0
@@ -136,10 +118,8 @@ rotation = 3.14159
 controls = "joy2"
 species = ExtResource( 16 )
 
-[node name="Camera" parent="." index="6"]
+[node name="Camera" parent="." index="7"]
 zoom = Vector2( 62.5, 62.5 )
 smoothing_speed = 0.3
 
 [connection signal="item_rect_changed" from="BackgroundLayer/mantiacs_background" to="." method="_on_mantiacs_background_item_rect_changed"]
-
-[editable path="CanvasLayer/Pause"]

--- a/godot/combat/levels/sets/combat/skull_collector/2players.tscn
+++ b/godot/combat/levels/sets/combat/skull_collector/2players.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=21 format=2]
+[gd_scene load_steps=20 format=2]
 
 [ext_resource path="res://addons/geometry/GRegularPolygon.gd" type="Script" id=1]
 [ext_resource path="res://addons/geometry/GBeveledRect.gd" type="Script" id=2]
 [ext_resource path="res://addons/geometry/icons/GBeveledRect.svg" type="Texture" id=3]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=4]
 [ext_resource path="res://selection/characters/mantiacs_1.tres" type="Resource" id=5]
 [ext_resource path="res://combat/PlayerSpawner.tscn" type="PackedScene" id=6]
 [ext_resource path="res://combat/Arena.tscn" type="PackedScene" id=7]
@@ -71,7 +70,7 @@ scale = Vector2( 0.75, 0.75 )
 goal_owner = NodePath("../../../SpawnPositions/Players/p1")
 
 [node name="SpeciesDecal2" parent="Battlefield/Background" index="5" instance=ExtResource( 21 )]
-modulate = Color( 0.956863, 0.584314, 0.898039, 1 )
+modulate = Color( 0.847059, 0.286275, 0.960784, 1 )
 position = Vector2( 1200, -700 )
 rotation = 2.35619
 scale = Vector2( 0.75, 0.75 )
@@ -173,15 +172,7 @@ script = ExtResource( 1 )
 radius = 450
 sides = 4.0
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="10" instance=ExtResource( 4 )]
-position = Vector2( -1200, 700 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="11" instance=ExtResource( 4 )]
-position = Vector2( 1200, -700 )
-type = "rocket_gun"
-
-[node name="SkullVariants" parent="Battlefield/Middleground" index="12" instance=ExtResource( 12 )]
+[node name="SkullVariants" parent="Battlefield/Middleground" index="10" instance=ExtResource( 12 )]
 
 [node name="SkullHole" parent="Battlefield/Foreground" index="0" instance=ExtResource( 16 )]
 position = Vector2( -1600, 500 )

--- a/godot/combat/levels/sets/combat/skull_collector/3players.tscn
+++ b/godot/combat/levels/sets/combat/skull_collector/3players.tscn
@@ -1,11 +1,10 @@
-[gd_scene load_steps=22 format=2]
+[gd_scene load_steps=21 format=2]
 
 [ext_resource path="res://selection/characters/mantiacs_1.tres" type="Resource" id=1]
 [ext_resource path="res://selection/characters/pentagonions_1.tres" type="Resource" id=2]
 [ext_resource path="res://selection/characters/trixens_1.tres" type="Resource" id=3]
 [ext_resource path="res://addons/geometry/icons/GBeveledRect.svg" type="Texture" id=4]
 [ext_resource path="res://utils/CameraEye.tscn" type="PackedScene" id=5]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=6]
 [ext_resource path="res://combat/modes/SkullCollectors.tres" type="Resource" id=7]
 [ext_resource path="res://combat/levels/background/mantiacs.png" type="Texture" id=8]
 [ext_resource path="res://assets/sprites/environments/skull_deco.png" type="Texture" id=9]
@@ -72,7 +71,7 @@ scale = Vector2( 0.75, 0.75 )
 goal_owner = NodePath("../../../SpawnPositions/Players/p1")
 
 [node name="SpeciesDecal2" parent="Battlefield/Background" index="5" instance=ExtResource( 23 )]
-modulate = Color( 0.956863, 0.584314, 0.898039, 1 )
+modulate = Color( 0.847059, 0.286275, 0.960784, 1 )
 position = Vector2( 1400, -700 )
 rotation = 2.35619
 scale = Vector2( 0.75, 0.75 )
@@ -181,19 +180,7 @@ script = ExtResource( 20 )
 radius = 450
 sides = 4.0
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="10" instance=ExtResource( 6 )]
-position = Vector2( -1400, 700 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="11" instance=ExtResource( 6 )]
-position = Vector2( -1400, -700 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="12" instance=ExtResource( 6 )]
-position = Vector2( 1400, -700 )
-type = "rocket_gun"
-
-[node name="SkullVariants" parent="Battlefield/Middleground" index="13" instance=ExtResource( 10 )]
+[node name="SkullVariants" parent="Battlefield/Middleground" index="10" instance=ExtResource( 10 )]
 
 [node name="SkullHole" parent="Battlefield/Foreground" index="0" instance=ExtResource( 12 )]
 position = Vector2( -1800, 500 )
@@ -301,10 +288,8 @@ rotation = 0.785398
 controls = "kb2"
 species = ExtResource( 3 )
 
-[node name="Camera" parent="." index="6"]
+[node name="Camera" parent="." index="7"]
 zoom = Vector2( 1.42109e+10, 1.42109e+10 )
 smoothing_speed = 0.3
 
 [connection signal="item_rect_changed" from="BackgroundLayer/mantiacs_background" to="." method="_on_mantiacs_background_item_rect_changed"]
-
-[editable path="CanvasLayer/Pause"]

--- a/godot/combat/levels/sets/combat/skull_collector/4players.tscn
+++ b/godot/combat/levels/sets/combat/skull_collector/4players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=2]
+[gd_scene load_steps=22 format=2]
 
 [ext_resource path="res://selection/characters/mantiacs_1.tres" type="Resource" id=1]
 [ext_resource path="res://selection/characters/pentagonions_1.tres" type="Resource" id=2]
@@ -6,7 +6,6 @@
 [ext_resource path="res://selection/characters/trixens_1.tres" type="Resource" id=4]
 [ext_resource path="res://addons/geometry/icons/GBeveledRect.svg" type="Texture" id=5]
 [ext_resource path="res://utils/CameraEye.tscn" type="PackedScene" id=6]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=7]
 [ext_resource path="res://combat/modes/SkullCollectors.tres" type="Resource" id=8]
 [ext_resource path="res://combat/levels/background/mantiacs.png" type="Texture" id=9]
 [ext_resource path="res://assets/sprites/environments/skull_deco.png" type="Texture" id=10]
@@ -73,14 +72,14 @@ scale = Vector2( 0.75, 0.75 )
 goal_owner = NodePath("../../../SpawnPositions/Players/p1")
 
 [node name="SpeciesDecal2" parent="Battlefield/Background" index="5" instance=ExtResource( 24 )]
-modulate = Color( 0.956863, 0.584314, 0.898039, 1 )
+modulate = Color( 0.847059, 0.286275, 0.960784, 1 )
 position = Vector2( 1600, -700 )
 rotation = 2.35619
 scale = Vector2( 0.75, 0.75 )
 goal_owner = NodePath("../../../SpawnPositions/Players/p2")
 
 [node name="SpeciesDecal4" parent="Battlefield/Background" index="6" instance=ExtResource( 24 )]
-modulate = Color( 0.35, 0.566667, 1, 1 )
+modulate = Color( 0, 0.466667, 1, 1 )
 position = Vector2( 1600, 700 )
 rotation = 3.92699
 scale = Vector2( 0.75, 0.75 )
@@ -189,23 +188,7 @@ script = ExtResource( 21 )
 radius = 450
 sides = 4.0
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="10" instance=ExtResource( 7 )]
-position = Vector2( -1600, 700 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="11" instance=ExtResource( 7 )]
-position = Vector2( -1600, -700 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="12" instance=ExtResource( 7 )]
-position = Vector2( 1600, -700 )
-type = "rocket_gun"
-
-[node name="PowerUp4" parent="Battlefield/Middleground" index="13" instance=ExtResource( 7 )]
-position = Vector2( 1600, 700 )
-type = "rocket_gun"
-
-[node name="SkullVariants" parent="Battlefield/Middleground" index="14" instance=ExtResource( 11 )]
+[node name="SkullVariants" parent="Battlefield/Middleground" index="10" instance=ExtResource( 11 )]
 
 [node name="SkullHole" parent="Battlefield/Foreground" index="0" instance=ExtResource( 13 )]
 position = Vector2( -2000, 500 )
@@ -342,11 +325,9 @@ rotation = 3.92699
 controls = "kb2"
 species = ExtResource( 3 )
 
-[node name="Camera" parent="." index="6"]
+[node name="Camera" parent="." index="7"]
 current = false
 zoom = Vector2( 1.42109e+10, 1.42109e+10 )
 smoothing_speed = 0.3
 
 [connection signal="item_rect_changed" from="BackgroundLayer/mantiacs_background" to="." method="_on_mantiacs_background_item_rect_changed"]
-
-[editable path="CanvasLayer/Pause"]

--- a/godot/combat/levels/sets/conquest/board_conquest/2players.tscn
+++ b/godot/combat/levels/sets/conquest/board_conquest/2players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://addons/geometry/GRect.gd" type="Script" id=1]
 [ext_resource path="res://selection/characters/mantiacs_1.tres" type="Resource" id=3]
@@ -9,7 +9,6 @@
 [ext_resource path="res://combat/levels/background/trixen.png" type="Texture" id=8]
 [ext_resource path="res://combat/modes/BoardConquest.tres" type="Resource" id=9]
 [ext_resource path="res://actors/environments/Tile.tscn" type="PackedScene" id=10]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=11]
 
 [node name="Arena" instance=ExtResource( 7 )]
 size_multiplier = 2.5
@@ -1330,14 +1329,6 @@ rotation = 0.785398
 position = Vector2( 565.686, 1131.37 )
 rotation = 0.785398
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="1" instance=ExtResource( 11 )]
-position = Vector2( -1500, 1500 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="2" instance=ExtResource( 11 )]
-position = Vector2( 1500, -1500 )
-type = "rocket_gun"
-
 [node name="p1" parent="SpawnPositions/Players" index="0" instance=ExtResource( 6 )]
 position = Vector2( -1500, 1500 )
 rotation = -0.785402
@@ -1351,10 +1342,8 @@ controls = "joy2"
 species = ExtResource( 4 )
 cpu = true
 
-[node name="Camera" parent="." index="6"]
+[node name="Camera" parent="." index="7"]
 zoom = Vector2( 2.91038e+12, 2.91038e+12 )
 smoothing_speed = 0.3
 
 [connection signal="item_rect_changed" from="BackgroundLayer/mantiacs_background" to="." method="_on_mantiacs_background_item_rect_changed"]
-
-[editable path="CanvasLayer/Pause"]

--- a/godot/combat/levels/sets/conquest/board_conquest/3players.tscn
+++ b/godot/combat/levels/sets/conquest/board_conquest/3players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://addons/geometry/GRect.gd" type="Script" id=1]
 [ext_resource path="res://combat/modes/BoardConquest.tres" type="Resource" id=3]
@@ -10,7 +10,6 @@
 [ext_resource path="res://combat/PlayerSpawner.tscn" type="PackedScene" id=9]
 [ext_resource path="res://selection/characters/robolords_1.tres" type="Resource" id=10]
 [ext_resource path="res://selection/characters/auriels_1.tres" type="Resource" id=11]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=12]
 
 [node name="Arena" instance=ExtResource( 4 )]
 size_multiplier = 2.5
@@ -1301,18 +1300,6 @@ rotation = 0.785398
 position = Vector2( 565.686, 1131.37 )
 rotation = 0.785398
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="1" instance=ExtResource( 12 )]
-position = Vector2( -1500, 1500 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="2" instance=ExtResource( 12 )]
-position = Vector2( 1500, 1500 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="3" instance=ExtResource( 12 )]
-position = Vector2( 1500, -1500 )
-type = "rocket_gun"
-
 [node name="p1" parent="SpawnPositions/Players" index="0" instance=ExtResource( 9 )]
 position = Vector2( -1500, 1500 )
 rotation = -0.785402
@@ -1331,10 +1318,8 @@ rotation = 3.92699
 controls = "joy3"
 species = ExtResource( 11 )
 
-[node name="Camera" parent="." index="6"]
+[node name="Camera" parent="." index="7"]
 zoom = Vector2( 2.91038e+12, 2.91038e+12 )
 smoothing_speed = 0.3
 
 [connection signal="item_rect_changed" from="BackgroundLayer/mantiacs_background" to="." method="_on_mantiacs_background_item_rect_changed"]
-
-[editable path="CanvasLayer/Pause"]

--- a/godot/combat/levels/sets/conquest/board_conquest/4players.tscn
+++ b/godot/combat/levels/sets/conquest/board_conquest/4players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://addons/geometry/GRect.gd" type="Script" id=1]
 [ext_resource path="res://combat/modes/BoardConquest.tres" type="Resource" id=3]
@@ -11,7 +11,6 @@
 [ext_resource path="res://selection/characters/auriels_1.tres" type="Resource" id=10]
 [ext_resource path="res://selection/characters/robolords_1.tres" type="Resource" id=11]
 [ext_resource path="res://selection/characters/umidorians_1.tres" type="Resource" id=12]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=13]
 
 [node name="Arena" instance=ExtResource( 4 )]
 size_multiplier = 2.5
@@ -1272,22 +1271,6 @@ rotation = 0.785398
 position = Vector2( 565.686, 1131.37 )
 rotation = 0.785398
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="1" instance=ExtResource( 13 )]
-position = Vector2( -1500, 1500 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="2" instance=ExtResource( 13 )]
-position = Vector2( 1500, 1500 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="3" instance=ExtResource( 13 )]
-position = Vector2( 1500, -1500 )
-type = "rocket_gun"
-
-[node name="PowerUp4" parent="Battlefield/Middleground" index="4" instance=ExtResource( 13 )]
-position = Vector2( -1500, -1500 )
-type = "rocket_gun"
-
 [node name="p1" parent="SpawnPositions/Players" index="0" instance=ExtResource( 9 )]
 position = Vector2( -1500, 1500 )
 rotation = -0.785402
@@ -1316,10 +1299,8 @@ controls = "joy4"
 species = ExtResource( 12 )
 cpu = true
 
-[node name="Camera" parent="." index="6"]
+[node name="Camera" parent="." index="7"]
 zoom = Vector2( 2.91038e+12, 2.91038e+12 )
 smoothing_speed = 0.3
 
 [connection signal="item_rect_changed" from="BackgroundLayer/mantiacs_background" to="." method="_on_mantiacs_background_item_rect_changed"]
-
-[editable path="CanvasLayer/Pause"]

--- a/godot/combat/levels/sets/conquest/marble_conquest/2players.tscn
+++ b/godot/combat/levels/sets/conquest/marble_conquest/2players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://selection/characters/robolords_1.tres" type="Resource" id=1]
 [ext_resource path="res://selection/characters/mantiacs_1.tres" type="Resource" id=2]
@@ -8,7 +8,6 @@
 [ext_resource path="res://combat/levels/background/trixen.png" type="Texture" id=6]
 [ext_resource path="res://combat/modes/MarbleConquest.tres" type="Resource" id=7]
 [ext_resource path="res://addons/geometry/GBeveledRect.gd" type="Script" id=8]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=9]
 [ext_resource path="res://actors/environments/Marble.tscn" type="PackedScene" id=12]
 
 [node name="Arena" instance=ExtResource( 3 )]
@@ -44,14 +43,6 @@ modulate = Color( 1, 1, 1, 0.9 )
 fg_color = Color( 0, 0.173333, 0.26, 1 )
 bg_color = Color( 0, 0.0156863, 0.0431373, 1 )
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="0" instance=ExtResource( 9 )]
-position = Vector2( -1400, 0 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="1" instance=ExtResource( 9 )]
-position = Vector2( 1400, 0 )
-type = "rocket_gun"
-
 [node name="Marble" parent="Battlefield/Foreground" index="0" instance=ExtResource( 12 )]
 
 [node name="Marble2" parent="Battlefield/Foreground" index="1" instance=ExtResource( 12 )]
@@ -77,10 +68,8 @@ rotation = 3.14159
 controls = "joy2"
 species = ExtResource( 1 )
 
-[node name="Camera" parent="." index="6"]
+[node name="Camera" parent="." index="7"]
 zoom = Vector2( 2.91038e+12, 2.91038e+12 )
 smoothing_speed = 0.3
 
 [connection signal="item_rect_changed" from="BackgroundLayer/mantiacs_background" to="." method="_on_mantiacs_background_item_rect_changed"]
-
-[editable path="CanvasLayer/Pause"]

--- a/godot/combat/levels/sets/conquest/marble_conquest/3players.tscn
+++ b/godot/combat/levels/sets/conquest/marble_conquest/3players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://selection/characters/robolords_1.tres" type="Resource" id=1]
 [ext_resource path="res://selection/characters/mantiacs_1.tres" type="Resource" id=2]
@@ -8,7 +8,6 @@
 [ext_resource path="res://combat/levels/background/trixen.png" type="Texture" id=6]
 [ext_resource path="res://combat/modes/MarbleConquest.tres" type="Resource" id=7]
 [ext_resource path="res://addons/geometry/GBeveledRect.gd" type="Script" id=8]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=9]
 [ext_resource path="res://selection/characters/umidorians_1.tres" type="Resource" id=10]
 [ext_resource path="res://actors/environments/Marble.tscn" type="PackedScene" id=12]
 
@@ -45,18 +44,6 @@ modulate = Color( 1, 1, 1, 0.9 )
 fg_color = Color( 0, 0.173333, 0.26, 1 )
 bg_color = Color( 0, 0.0156863, 0.0431373, 1 )
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="0" instance=ExtResource( 9 )]
-position = Vector2( -1400, 0 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="1" instance=ExtResource( 9 )]
-position = Vector2( 1400, 0 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="2" instance=ExtResource( 9 )]
-position = Vector2( 0, -1400 )
-type = "rocket_gun"
-
 [node name="Marble" parent="Battlefield/Foreground" index="0" instance=ExtResource( 12 )]
 
 [node name="Marble2" parent="Battlefield/Foreground" index="1" instance=ExtResource( 12 )]
@@ -88,10 +75,8 @@ rotation = 1.5708
 controls = "joy3"
 species = ExtResource( 10 )
 
-[node name="Camera" parent="." index="6"]
+[node name="Camera" parent="." index="7"]
 zoom = Vector2( 2.91038e+12, 2.91038e+12 )
 smoothing_speed = 0.3
 
 [connection signal="item_rect_changed" from="BackgroundLayer/mantiacs_background" to="." method="_on_mantiacs_background_item_rect_changed"]
-
-[editable path="CanvasLayer/Pause"]

--- a/godot/combat/levels/sets/conquest/marble_conquest/4players.tscn
+++ b/godot/combat/levels/sets/conquest/marble_conquest/4players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://selection/characters/robolords_1.tres" type="Resource" id=1]
 [ext_resource path="res://selection/characters/mantiacs_1.tres" type="Resource" id=2]
@@ -8,7 +8,6 @@
 [ext_resource path="res://combat/levels/background/trixen.png" type="Texture" id=6]
 [ext_resource path="res://combat/modes/MarbleConquest.tres" type="Resource" id=7]
 [ext_resource path="res://addons/geometry/GBeveledRect.gd" type="Script" id=8]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=9]
 [ext_resource path="res://selection/characters/umidorians_1.tres" type="Resource" id=10]
 [ext_resource path="res://selection/characters/eelectrons_1.tres" type="Resource" id=11]
 [ext_resource path="res://actors/environments/Marble.tscn" type="PackedScene" id=12]
@@ -45,22 +44,6 @@ bevel_se = 1400
 modulate = Color( 1, 1, 1, 0.9 )
 fg_color = Color( 0, 0.173333, 0.26, 1 )
 bg_color = Color( 0, 0.0156863, 0.0431373, 1 )
-
-[node name="PowerUp" parent="Battlefield/Middleground" index="0" instance=ExtResource( 9 )]
-position = Vector2( -1400, 0 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="1" instance=ExtResource( 9 )]
-position = Vector2( 1400, 0 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="2" instance=ExtResource( 9 )]
-position = Vector2( 0, -1400 )
-type = "rocket_gun"
-
-[node name="PowerUp4" parent="Battlefield/Middleground" index="3" instance=ExtResource( 9 )]
-position = Vector2( 0, 1400 )
-type = "rocket_gun"
 
 [node name="Marble" parent="Battlefield/Foreground" index="0" instance=ExtResource( 12 )]
 
@@ -99,10 +82,8 @@ rotation = -1.5708
 controls = "joy4"
 species = ExtResource( 11 )
 
-[node name="Camera" parent="." index="6"]
+[node name="Camera" parent="." index="7"]
 zoom = Vector2( 2.91038e+12, 2.91038e+12 )
 smoothing_speed = 0.3
 
 [connection signal="item_rect_changed" from="BackgroundLayer/mantiacs_background" to="." method="_on_mantiacs_background_item_rect_changed"]
-
-[editable path="CanvasLayer/Pause"]

--- a/godot/combat/levels/sets/core/deathmatch/2players.tscn
+++ b/godot/combat/levels/sets/core/deathmatch/2players.tscn
@@ -474,7 +474,7 @@ match_progress_trigger = 0.25
 jitter = 2.0
 
 [node name="PowerUp" parent="Battlefield/Middleground/Variants/E/DramaticSpawner" index="0" instance=ExtResource( 18 )]
-type = "plate"
+type = "shields"
 tease = true
 random_types = [ "plate", "shields" ]
 
@@ -495,14 +495,6 @@ chance = 0.4
 [node name="PowerUp" parent="Battlefield/Middleground/Variants/E/DramaticSpawner3" index="0" instance=ExtResource( 18 )]
 type = "shields"
 tease = true
-
-[node name="PowerUp" parent="Battlefield/Middleground" index="9" instance=ExtResource( 18 )]
-position = Vector2( -1300, 900 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="10" instance=ExtResource( 18 )]
-position = Vector2( 1300, -900 )
-type = "rocket_gun"
 
 [node name="p1" parent="SpawnPositions/Players" index="0" instance=ExtResource( 9 )]
 position = Vector2( -1300, 900 )

--- a/godot/combat/levels/sets/core/deathmatch/3players.tscn
+++ b/godot/combat/levels/sets/core/deathmatch/3players.tscn
@@ -203,19 +203,7 @@ rotation = 1.5708
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Battlefield/Middleground/Wall16" index="7" groups=["animation_if_additional_lasers"]]
 anims/Default = SubResource( 2 )
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="8" instance=ExtResource( 16 )]
-position = Vector2( -1400, 900 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="9" instance=ExtResource( 16 )]
-position = Vector2( 1400, 900 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="10" instance=ExtResource( 16 )]
-position = Vector2( 1400, -900 )
-type = "rocket_gun"
-
-[node name="Variants" parent="Battlefield/Middleground" index="11" instance=ExtResource( 18 )]
+[node name="Variants" parent="Battlefield/Middleground" index="8" instance=ExtResource( 18 )]
 
 [node name="A" type="Node2D" parent="Battlefield/Middleground/Variants" index="0"]
 
@@ -303,7 +291,7 @@ match_progress_trigger = 0.4
 chance = 0.8
 
 [node name="PowerUp" parent="Battlefield/Middleground/Variants/A/DramaticSpawner7" index="0" instance=ExtResource( 16 )]
-type = "plate"
+type = "shields"
 tease = true
 random_types = [ "plate", "shields" ]
 

--- a/godot/combat/levels/sets/core/deathmatch/4players.tscn
+++ b/godot/combat/levels/sets/core/deathmatch/4players.tscn
@@ -204,23 +204,7 @@ rotation = 1.5708
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Battlefield/Middleground/Wall18" index="7" groups=["animation_if_additional_lasers"]]
 anims/Default = SubResource( 2 )
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="8" instance=ExtResource( 17 )]
-position = Vector2( -1500, 1000 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="9" instance=ExtResource( 17 )]
-position = Vector2( 1500, 1000 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="10" instance=ExtResource( 17 )]
-position = Vector2( 1500, -1000 )
-type = "rocket_gun"
-
-[node name="PowerUp4" parent="Battlefield/Middleground" index="11" instance=ExtResource( 17 )]
-position = Vector2( -1500, -1000 )
-type = "rocket_gun"
-
-[node name="Variants" parent="Battlefield/Middleground" index="12" instance=ExtResource( 21 )]
+[node name="Variants" parent="Battlefield/Middleground" index="8" instance=ExtResource( 21 )]
 
 [node name="A" type="Node2D" parent="Battlefield/Middleground/Variants" index="0"]
 visible = false
@@ -327,7 +311,7 @@ chance = 0.8
 
 [node name="PowerUp" parent="Battlefield/Middleground/Variants/A/DramaticSpawner7" index="0" instance=ExtResource( 17 )]
 position = Vector2( 200, 200 )
-type = "plate"
+type = "shields"
 tease = true
 random_types = [ "plate", "shields" ]
 
@@ -436,7 +420,7 @@ jitter = 4.0
 chance = 0.8
 
 [node name="PowerUp" parent="Battlefield/Middleground/Variants/B/DramaticSpawner5" index="0" instance=ExtResource( 17 )]
-type = "plate"
+type = "shields"
 tease = true
 random_types = [ "shields", "plate" ]
 
@@ -447,7 +431,7 @@ jitter = 4.0
 chance = 0.8
 
 [node name="PowerUp" parent="Battlefield/Middleground/Variants/B/DramaticSpawner6" index="0" instance=ExtResource( 17 )]
-type = "shields"
+type = "plate"
 tease = true
 random_types = [ "shields", "plate" ]
 
@@ -590,7 +574,7 @@ match_progress_trigger = 0.25
 jitter = 2.0
 
 [node name="PowerUp" parent="Battlefield/Middleground/Variants/E/DramaticSpawner" index="0" instance=ExtResource( 17 )]
-type = "plate"
+type = "shields"
 tease = true
 random_types = [ "plate", "shields" ]
 

--- a/godot/combat/levels/sets/core/diamondsnatch/2players.tscn
+++ b/godot/combat/levels/sets/core/diamondsnatch/2players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=2]
+[gd_scene load_steps=21 format=2]
 
 [ext_resource path="res://addons/geometry/icons/GRect.svg" type="Texture" id=1]
 [ext_resource path="res://addons/geometry/GRegularPolygon.gd" type="Script" id=2]
@@ -18,7 +18,6 @@
 [ext_resource path="res://combat/collectables/BigDiamond.tscn" type="PackedScene" id=17]
 [ext_resource path="res://actors/weapons/Laser.tscn" type="PackedScene" id=18]
 [ext_resource path="res://combat/managers/SpawnerManager.tscn" type="PackedScene" id=20]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=22]
 
 [sub_resource type="Animation" id=1]
 resource_name = "Default"
@@ -597,14 +596,6 @@ rotation = -1.5708
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Battlefield/Middleground/Wall4" index="7" groups=["animation_if_additional_lasers"]]
 anims/Default = SubResource( 2 )
-
-[node name="PowerUp" parent="Battlefield/Middleground" index="48" instance=ExtResource( 22 )]
-position = Vector2( -600, 600 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="49" instance=ExtResource( 22 )]
-position = Vector2( 600, -600 )
-type = "rocket_gun"
 
 [node name="p1" parent="SpawnPositions/Players" index="0" instance=ExtResource( 9 )]
 position = Vector2( -600, 600 )

--- a/godot/combat/levels/sets/core/diamondsnatch/3players.tscn
+++ b/godot/combat/levels/sets/core/diamondsnatch/3players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=2]
+[gd_scene load_steps=22 format=2]
 
 [ext_resource path="res://addons/geometry/icons/GRect.svg" type="Texture" id=1]
 [ext_resource path="res://addons/geometry/GRegularPolygon.gd" type="Script" id=2]
@@ -19,7 +19,6 @@
 [ext_resource path="res://actors/weapons/Laser.tscn" type="PackedScene" id=17]
 [ext_resource path="res://combat/levels/background/takonauts.png" type="Texture" id=18]
 [ext_resource path="res://combat/managers/SpawnerManager.tscn" type="PackedScene" id=20]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=21]
 
 [sub_resource type="Animation" id=1]
 resource_name = "Default"
@@ -603,18 +602,6 @@ rotation = -1.5708
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Battlefield/Middleground/Wall4" index="7" groups=["animation_if_additional_lasers"]]
 anims/Default = SubResource( 2 )
-
-[node name="PowerUp" parent="Battlefield/Middleground" index="48" instance=ExtResource( 21 )]
-position = Vector2( -600, 600 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="49" instance=ExtResource( 21 )]
-position = Vector2( 600, 600 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="50" instance=ExtResource( 21 )]
-position = Vector2( 600, -600 )
-type = "rocket_gun"
 
 [node name="p1" parent="SpawnPositions/Players" index="0" instance=ExtResource( 9 )]
 position = Vector2( -600, 600 )

--- a/godot/combat/levels/sets/core/diamondsnatch/4players.tscn
+++ b/godot/combat/levels/sets/core/diamondsnatch/4players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=2]
+[gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://addons/geometry/icons/GRect.svg" type="Texture" id=1]
 [ext_resource path="res://addons/geometry/GRegularPolygon.gd" type="Script" id=2]
@@ -20,7 +20,6 @@
 [ext_resource path="res://combat/levels/background/takonauts.png" type="Texture" id=18]
 [ext_resource path="res://selection/characters/auriels_1.tres" type="Resource" id=19]
 [ext_resource path="res://combat/managers/SpawnerManager.tscn" type="PackedScene" id=21]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=22]
 
 [sub_resource type="Animation" id=1]
 resource_name = "Default"
@@ -606,22 +605,6 @@ rotation = -1.5708
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Battlefield/Middleground/Wall4" index="7" groups=["animation_if_additional_lasers"]]
 anims/Default = SubResource( 2 )
-
-[node name="PowerUp" parent="Battlefield/Middleground" index="48" instance=ExtResource( 22 )]
-position = Vector2( -600, 600 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="49" instance=ExtResource( 22 )]
-position = Vector2( 600, 600 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="50" instance=ExtResource( 22 )]
-position = Vector2( 600, -600 )
-type = "rocket_gun"
-
-[node name="PowerUp4" parent="Battlefield/Middleground" index="51" instance=ExtResource( 22 )]
-position = Vector2( -600, -600 )
-type = "rocket_gun"
 
 [node name="p1" parent="SpawnPositions/Players" index="0" instance=ExtResource( 9 )]
 position = Vector2( -600, 600 )

--- a/godot/combat/levels/sets/core/slam_a_gon/2players.tscn
+++ b/godot/combat/levels/sets/core/slam_a_gon/2players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=2]
+[gd_scene load_steps=20 format=2]
 
 [ext_resource path="res://addons/geometry/GRegularPolygon.gd" type="Script" id=1]
 [ext_resource path="res://addons/geometry/GCircle.gd" type="Script" id=2]
@@ -18,7 +18,6 @@
 [ext_resource path="res://actors/environments/SpeciesDecal.tscn" type="PackedScene" id=16]
 [ext_resource path="res://actors/environments/PentaGoal.tscn" type="PackedScene" id=17]
 [ext_resource path="res://assets/shaders/Clock.shader" type="Shader" id=18]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=19]
 
 [sub_resource type="ShaderMaterial" id=1]
 resource_local_to_scene = true
@@ -160,14 +159,6 @@ sides = 4.0
 [node name="Laser2" parent="Battlefield/Middleground/Wall2" index="8" groups=["additional_lasers"] instance=ExtResource( 9 )]
 position = Vector2( 0, -51 )
 rotation = -1.5708
-
-[node name="PowerUp" parent="Battlefield/Middleground" index="10" instance=ExtResource( 19 )]
-position = Vector2( -1400, 0 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="11" instance=ExtResource( 19 )]
-position = Vector2( 1400, 0 )
-type = "rocket_gun"
 
 [node name="Ball" parent="Battlefield/Foreground" index="0" instance=ExtResource( 12 )]
 

--- a/godot/combat/levels/sets/core/slam_a_gon/3players.tscn
+++ b/godot/combat/levels/sets/core/slam_a_gon/3players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=2]
+[gd_scene load_steps=19 format=2]
 
 [ext_resource path="res://addons/geometry/GRegularPolygon.gd" type="Script" id=1]
 [ext_resource path="res://addons/geometry/GCircle.gd" type="Script" id=2]
@@ -18,7 +18,6 @@
 [ext_resource path="res://assets/patterns/stripes.png" type="Texture" id=16]
 [ext_resource path="res://actors/environments/SpeciesDecal.tscn" type="PackedScene" id=17]
 [ext_resource path="res://actors/environments/PentaGoal.tscn" type="PackedScene" id=18]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=19]
 
 [node name="Arena" instance=ExtResource( 8 )]
 size_multiplier = 2.5
@@ -222,18 +221,6 @@ sides = 4.0
 [node name="Laser" parent="Battlefield/Middleground/Node2D3/Wall" index="8" groups=["additional_lasers"] instance=ExtResource( 10 )]
 position = Vector2( -50, 1 )
 rotation = 3.14159
-
-[node name="PowerUp" parent="Battlefield/Middleground" index="6" instance=ExtResource( 19 )]
-position = Vector2( 0, 1400 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="7" instance=ExtResource( 19 )]
-position = Vector2( -1212.44, -700 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="8" instance=ExtResource( 19 )]
-position = Vector2( 1212.44, -700 )
-type = "rocket_gun"
 
 [node name="Ball" parent="Battlefield/Foreground" index="0" instance=ExtResource( 13 )]
 

--- a/godot/combat/levels/sets/core/take_the_crown/3players.tscn
+++ b/godot/combat/levels/sets/core/take_the_crown/3players.tscn
@@ -1,6 +1,5 @@
-[gd_scene load_steps=20 format=2]
+[gd_scene load_steps=19 format=2]
 
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/geometry/GBeveledRect.gd" type="Script" id=2]
 [ext_resource path="res://addons/geometry/icons/GBeveledRect.svg" type="Texture" id=3]
 [ext_resource path="res://selection/characters/mantiacs_1.tres" type="Resource" id=4]
@@ -167,19 +166,7 @@ sides = 4.0
 playback_speed = 0.2
 anims/Rotate = SubResource( 8 )
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="3" instance=ExtResource( 1 )]
-position = Vector2( -450, -450 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="4" instance=ExtResource( 1 )]
-position = Vector2( 450, -450 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="5" instance=ExtResource( 1 )]
-position = Vector2( 450, 450 )
-type = "rocket_gun"
-
-[node name="Wall" parent="Battlefield/Middleground" index="6" instance=ExtResource( 6 )]
+[node name="Wall" parent="Battlefield/Middleground" index="3" instance=ExtResource( 6 )]
 position = Vector2( 0, -1100 )
 offset = 400
 solid_line_color = Color( 1.13, 0.78, 0.47, 1 )
@@ -195,7 +182,7 @@ position = Vector2( 0, 203 )
 rotation = 1.5708
 collision_mask = 140304
 
-[node name="Wall2" parent="Battlefield/Middleground" index="7" instance=ExtResource( 6 )]
+[node name="Wall2" parent="Battlefield/Middleground" index="4" instance=ExtResource( 6 )]
 position = Vector2( 0, 1100 )
 solid_line_color = Color( 1.13, 0.78, 0.47, 1 )
 

--- a/godot/combat/levels/sets/core/take_the_crown/4players.tscn
+++ b/godot/combat/levels/sets/core/take_the_crown/4players.tscn
@@ -1,6 +1,5 @@
-[gd_scene load_steps=21 format=2]
+[gd_scene load_steps=20 format=2]
 
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/geometry/GBeveledRect.gd" type="Script" id=2]
 [ext_resource path="res://addons/geometry/icons/GBeveledRect.svg" type="Texture" id=3]
 [ext_resource path="res://selection/characters/mantiacs_1.tres" type="Resource" id=4]
@@ -168,23 +167,7 @@ sides = 4.0
 playback_speed = 0.2
 anims/Rotate = SubResource( 8 )
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="3" instance=ExtResource( 1 )]
-position = Vector2( 550, -550 )
-type = "rocket_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="4" instance=ExtResource( 1 )]
-position = Vector2( -550, -550 )
-type = "rocket_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="5" instance=ExtResource( 1 )]
-position = Vector2( -550, 550 )
-type = "rocket_gun"
-
-[node name="PowerUp4" parent="Battlefield/Middleground" index="6" instance=ExtResource( 1 )]
-position = Vector2( 550, 550 )
-type = "rocket_gun"
-
-[node name="Wall" parent="Battlefield/Middleground" index="7" instance=ExtResource( 6 )]
+[node name="Wall" parent="Battlefield/Middleground" index="3" instance=ExtResource( 6 )]
 position = Vector2( 0, -1300 )
 offset = 400
 solid_line_color = Color( 1.13, 0.78, 0.47, 1 )
@@ -200,7 +183,7 @@ position = Vector2( 0, 255 )
 rotation = 1.5708
 collision_mask = 140304
 
-[node name="Wall2" parent="Battlefield/Middleground" index="8" instance=ExtResource( 6 )]
+[node name="Wall2" parent="Battlefield/Middleground" index="4" instance=ExtResource( 6 )]
 position = Vector2( 0, 1300 )
 solid_line_color = Color( 1.13, 0.78, 0.47, 1 )
 

--- a/godot/combat/levels/sets/crown/queen_of_the_hive/2players.tscn
+++ b/godot/combat/levels/sets/crown/queen_of_the_hive/2players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://addons/geometry/icons/GRegularPolygon.svg" type="Texture" id=1]
 [ext_resource path="res://addons/geometry/GRegularPolygon.gd" type="Script" id=2]
@@ -12,7 +12,6 @@
 [ext_resource path="res://combat/modes/QueenOfTheHive.tres" type="Resource" id=10]
 [ext_resource path="res://actors/environments/Tile.tscn" type="PackedScene" id=11]
 [ext_resource path="res://actors/environments/NoCrownZone.tscn" type="PackedScene" id=12]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=13]
 
 [node name="Arena" instance=ExtResource( 4 )]
 size_multiplier = 2.5
@@ -770,14 +769,6 @@ script = ExtResource( 2 )
 radius = 500
 sides = 3.0
 rotation_degrees = 90.0
-
-[node name="PowerUp" parent="Battlefield/Middleground" index="3" instance=ExtResource( 13 )]
-position = Vector2( -1600, 0 )
-type = "spike_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="4" instance=ExtResource( 13 )]
-position = Vector2( 1600, 0 )
-type = "spike_gun"
 
 [node name="Ball" parent="Battlefield/Foreground" index="0" instance=ExtResource( 9 )]
 type = "bee_crown"

--- a/godot/combat/levels/sets/crown/queen_of_the_hive/3players.tscn
+++ b/godot/combat/levels/sets/crown/queen_of_the_hive/3players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://addons/geometry/icons/GRegularPolygon.svg" type="Texture" id=1]
 [ext_resource path="res://addons/geometry/GRegularPolygon.gd" type="Script" id=2]
@@ -13,7 +13,6 @@
 [ext_resource path="res://actors/environments/Tile.tscn" type="PackedScene" id=11]
 [ext_resource path="res://actors/environments/NoCrownZone.tscn" type="PackedScene" id=12]
 [ext_resource path="res://selection/characters/trixens_1.tres" type="Resource" id=13]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=14]
 
 [node name="Arena" instance=ExtResource( 4 )]
 size_multiplier = 2.5
@@ -849,18 +848,6 @@ visible_decorations = false
 script = ExtResource( 2 )
 radius = 400
 rotation_degrees = 30.0
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="2" instance=ExtResource( 14 )]
-position = Vector2( -1665, 0 )
-type = "spike_gun"
-
-[node name="PowerUp" parent="Battlefield/Middleground" index="3" instance=ExtResource( 14 )]
-position = Vector2( 832.5, -1441.94 )
-type = "spike_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="4" instance=ExtResource( 14 )]
-position = Vector2( 832.5, 1441.94 )
-type = "spike_gun"
 
 [node name="Ball" parent="Battlefield/Foreground" index="0" instance=ExtResource( 9 )]
 type = "bee_crown"

--- a/godot/combat/levels/sets/crown/queen_of_the_hive/4players.tscn
+++ b/godot/combat/levels/sets/crown/queen_of_the_hive/4players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://addons/geometry/GConvexPolygon.gd" type="Script" id=1]
 [ext_resource path="res://addons/geometry/GRegularPolygon.gd" type="Script" id=2]
@@ -13,7 +13,6 @@
 [ext_resource path="res://actors/environments/Tile.tscn" type="PackedScene" id=11]
 [ext_resource path="res://selection/characters/umidorians_1.tres" type="Resource" id=12]
 [ext_resource path="res://selection/characters/trixens_1.tres" type="Resource" id=13]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=14]
 [ext_resource path="res://actors/environments/NoCrownZone.tscn" type="PackedScene" id=16]
 
 [node name="Arena" instance=ExtResource( 4 )]
@@ -1428,22 +1427,6 @@ symbol_scale = 1.0
 script = ExtResource( 2 )
 radius = 200
 sides = 3.0
-
-[node name="PowerUp" parent="Battlefield/Middleground" index="5" instance=ExtResource( 14 )]
-position = Vector2( -1971, 0 )
-type = "spike_gun"
-
-[node name="PowerUp4" parent="Battlefield/Middleground" index="6" instance=ExtResource( 14 )]
-position = Vector2( 1971, 0 )
-type = "spike_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="7" instance=ExtResource( 14 )]
-position = Vector2( -933.5, -1550.24 )
-type = "spike_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="8" instance=ExtResource( 14 )]
-position = Vector2( 933.5, 1550.24 )
-type = "spike_gun"
 
 [node name="Ball" parent="Battlefield/Foreground" index="0" instance=ExtResource( 9 )]
 type = "bee_crown"

--- a/godot/combat/levels/singles/bobble/2players.tscn
+++ b/godot/combat/levels/singles/bobble/2players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://combat/Arena.tscn" type="PackedScene" id=1]
 [ext_resource path="res://combat/modes/AlchemicalBombing.tres" type="Resource" id=2]
@@ -10,7 +10,6 @@
 [ext_resource path="res://combat/PlayerSpawner.tscn" type="PackedScene" id=8]
 [ext_resource path="res://actors/environments/ChemicalBond.tscn" type="PackedScene" id=9]
 [ext_resource path="res://selection/characters/mantiacs_1.tres" type="Resource" id=10]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=11]
 [ext_resource path="res://selection/characters/robolords_1.tres" type="Resource" id=12]
 [ext_resource path="res://actors/environments/Gel.tscn" type="PackedScene" id=13]
 [ext_resource path="res://addons/geometry/GCircle.gd" type="Script" id=14]
@@ -211,21 +210,13 @@ node_b = NodePath("../../Bubble12")
 node_a = NodePath("..")
 node_b = NodePath("../../Bubble8")
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="14" instance=ExtResource( 11 )]
-position = Vector2( -1000, 0 )
-type = "bubble_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="15" instance=ExtResource( 11 )]
-position = Vector2( 1000, 0 )
-type = "bubble_gun"
-
-[node name="Gel" parent="Battlefield/Middleground" index="16" instance=ExtResource( 13 )]
+[node name="Gel" parent="Battlefield/Middleground" index="14" instance=ExtResource( 13 )]
 position = Vector2( 0, -1300 )
 rotation = 1.5708
 width = 600
 depth = 50
 
-[node name="Gel2" parent="Battlefield/Middleground" index="17" instance=ExtResource( 13 )]
+[node name="Gel2" parent="Battlefield/Middleground" index="15" instance=ExtResource( 13 )]
 position = Vector2( 0, 1350 )
 rotation = 4.71239
 width = 600
@@ -242,10 +233,8 @@ rotation = 0.0
 controls = "joy1"
 species = ExtResource( 10 )
 
-[node name="Camera" parent="." index="6"]
+[node name="Camera" parent="." index="7"]
 zoom = Vector2( 3.30873e+20, 3.30873e+20 )
 smoothing_speed = 0.3
 
 [connection signal="item_rect_changed" from="BackgroundLayer/mantiacs_background" to="." method="_on_mantiacs_background_item_rect_changed"]
-
-[editable path="CanvasLayer/Pause"]

--- a/godot/combat/levels/singles/bobble/3players.tscn
+++ b/godot/combat/levels/singles/bobble/3players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://combat/Arena.tscn" type="PackedScene" id=1]
 [ext_resource path="res://combat/modes/AlchemicalBombing.tres" type="Resource" id=2]
@@ -10,9 +10,7 @@
 [ext_resource path="res://combat/PlayerSpawner.tscn" type="PackedScene" id=8]
 [ext_resource path="res://actors/environments/ChemicalBond.tscn" type="PackedScene" id=9]
 [ext_resource path="res://selection/characters/mantiacs_1.tres" type="Resource" id=10]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=11]
 [ext_resource path="res://selection/characters/robolords_1.tres" type="Resource" id=12]
-[ext_resource path="res://actors/environments/Wall.gd" type="Script" id=13]
 [ext_resource path="res://actors/environments/Gel.tscn" type="PackedScene" id=14]
 [ext_resource path="res://addons/geometry/GCircle.gd" type="Script" id=15]
 
@@ -49,15 +47,9 @@ modulate = Color( 1, 1, 1, 0.9 )
 fg_color = Color( 0.372, 0.62, 0.62, 1 )
 bg_color = Color( 0.336, 0.56, 0.56, 1 )
 
-[node name="Wall" type="StaticBody2D" parent="Battlefield/Background" index="4" groups=["wall"] instance=ExtResource( 4 )]
+[node name="Wall" parent="Battlefield/Background" index="4" instance=ExtResource( 4 )]
 collision_layer = 2147483648
-collision_mask = 270337
-script = ExtResource( 13 )
-__meta__ = {
-"_edit_group_": true
-}
 offset = 400
-elongation = 100
 type = 4
 
 [node name="GCircle" type="Node" parent="Battlefield/Background/Wall" index="8"]
@@ -219,31 +211,19 @@ node_b = NodePath("../../Bubble12")
 node_a = NodePath("..")
 node_b = NodePath("../../Bubble8")
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="14" instance=ExtResource( 11 )]
-position = Vector2( -1050, 0 )
-type = "bubble_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="15" instance=ExtResource( 11 )]
-position = Vector2( 1050, 0 )
-type = "bubble_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="16" instance=ExtResource( 11 )]
-position = Vector2( 0, -1050 )
-type = "bubble_gun"
-
-[node name="Gel" parent="Battlefield/Middleground" index="17" instance=ExtResource( 14 )]
+[node name="Gel" parent="Battlefield/Middleground" index="14" instance=ExtResource( 14 )]
 position = Vector2( 0, -1600 )
 rotation = 1.5708
 width = 500
 depth = 50
 
-[node name="Gel2" parent="Battlefield/Middleground" index="18" instance=ExtResource( 14 )]
+[node name="Gel2" parent="Battlefield/Middleground" index="15" instance=ExtResource( 14 )]
 position = Vector2( -1385.64, 800 )
 rotation = -0.523598
 width = 500
 depth = 50
 
-[node name="Gel3" parent="Battlefield/Middleground" index="19" instance=ExtResource( 14 )]
+[node name="Gel3" parent="Battlefield/Middleground" index="16" instance=ExtResource( 14 )]
 position = Vector2( 1385.64, 800 )
 rotation = -2.61799
 width = 500
@@ -266,10 +246,8 @@ rotation = 1.5708
 controls = "joy1"
 species = ExtResource( 10 )
 
-[node name="Camera" parent="." index="6"]
+[node name="Camera" parent="." index="7"]
 zoom = Vector2( 3.30873e+20, 3.30873e+20 )
 smoothing_speed = 0.3
 
 [connection signal="item_rect_changed" from="BackgroundLayer/mantiacs_background" to="." method="_on_mantiacs_background_item_rect_changed"]
-
-[editable path="CanvasLayer/Pause"]

--- a/godot/combat/levels/singles/bobble/4players.tscn
+++ b/godot/combat/levels/singles/bobble/4players.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://addons/geometry/GRegularPolygon.gd" type="Script" id=1]
 [ext_resource path="res://addons/geometry/icons/GRegularPolygon.svg" type="Texture" id=2]
@@ -13,8 +13,6 @@
 [ext_resource path="res://selection/characters/robolords_1.tres" type="Resource" id=11]
 [ext_resource path="res://selection/characters/trixens_1.tres" type="Resource" id=12]
 [ext_resource path="res://selection/characters/umidorians_1.tres" type="Resource" id=13]
-[ext_resource path="res://combat/collectables/PowerUp.tscn" type="PackedScene" id=14]
-[ext_resource path="res://actors/environments/Wall.gd" type="Script" id=15]
 [ext_resource path="res://actors/environments/Gel.tscn" type="PackedScene" id=16]
 [ext_resource path="res://addons/geometry/GCircle.gd" type="Script" id=17]
 
@@ -51,15 +49,9 @@ modulate = Color( 1, 1, 1, 0.9 )
 fg_color = Color( 0.372, 0.62, 0.62, 1 )
 bg_color = Color( 0.336, 0.56, 0.56, 1 )
 
-[node name="Wall" type="StaticBody2D" parent="Battlefield/Background" index="4" groups=["wall"] instance=ExtResource( 8 )]
+[node name="Wall" parent="Battlefield/Background" index="4" instance=ExtResource( 8 )]
 collision_layer = 2147483648
-collision_mask = 270337
-script = ExtResource( 15 )
-__meta__ = {
-"_edit_group_": true
-}
 offset = 400
-elongation = 100
 type = 4
 
 [node name="GCircle" type="Node" parent="Battlefield/Background/Wall" index="8"]
@@ -221,41 +213,25 @@ node_b = NodePath("../../Bubble12")
 node_a = NodePath("..")
 node_b = NodePath("../../Bubble8")
 
-[node name="PowerUp" parent="Battlefield/Middleground" index="14" instance=ExtResource( 14 )]
-position = Vector2( -1100, 0 )
-type = "bubble_gun"
-
-[node name="PowerUp2" parent="Battlefield/Middleground" index="15" instance=ExtResource( 14 )]
-position = Vector2( 0, -1100 )
-type = "bubble_gun"
-
-[node name="PowerUp3" parent="Battlefield/Middleground" index="16" instance=ExtResource( 14 )]
-position = Vector2( 1100, 0 )
-type = "bubble_gun"
-
-[node name="PowerUp4" parent="Battlefield/Middleground" index="17" instance=ExtResource( 14 )]
-position = Vector2( 0, 1100 )
-type = "bubble_gun"
-
-[node name="Gel" parent="Battlefield/Middleground" index="18" instance=ExtResource( 16 )]
+[node name="Gel" parent="Battlefield/Middleground" index="14" instance=ExtResource( 16 )]
 position = Vector2( -1515.54, -875 )
 rotation = 0.523602
 width = 400
 depth = 50
 
-[node name="Gel2" parent="Battlefield/Middleground" index="19" instance=ExtResource( 16 )]
+[node name="Gel2" parent="Battlefield/Middleground" index="15" instance=ExtResource( 16 )]
 position = Vector2( -1515.54, 875 )
 rotation = -0.523598
 width = 400
 depth = 50
 
-[node name="Gel3" parent="Battlefield/Middleground" index="20" instance=ExtResource( 16 )]
+[node name="Gel3" parent="Battlefield/Middleground" index="16" instance=ExtResource( 16 )]
 position = Vector2( 1515.54, 875 )
 rotation = -2.61799
 width = 400
 depth = 50
 
-[node name="Gel4" parent="Battlefield/Middleground" index="21" instance=ExtResource( 16 )]
+[node name="Gel4" parent="Battlefield/Middleground" index="17" instance=ExtResource( 16 )]
 position = Vector2( 1515.54, -875 )
 rotation = 2.61799
 width = 400
@@ -288,10 +264,8 @@ controls = "joy1"
 species = ExtResource( 12 )
 cpu = true
 
-[node name="Camera" parent="." index="6"]
+[node name="Camera" parent="." index="7"]
 zoom = Vector2( 3.30873e+20, 3.30873e+20 )
 smoothing_speed = 0.3
 
 [connection signal="item_rect_changed" from="BackgroundLayer/mantiacs_background" to="." method="_on_mantiacs_background_item_rect_changed"]
-
-[editable path="CanvasLayer/Pause"]

--- a/godot/map/MapArena.tscn
+++ b/godot/map/MapArena.tscn
@@ -242,7 +242,7 @@ zoom = Vector2( 6, 6 )
 
 [node name="Camera" parent="." index="8"]
 current = false
-zoom = Vector2( 5.8775e+30, 5.8775e+30 )
+zoom = Vector2( 1.46937e+31, 1.46937e+31 )
 smoothing_speed = 0.3
 zoomMin = 4.0
 marginY = -225.0


### PR DESCRIPTION
Players don't see them (there's too much going on at the beginning of the level). Removed to reduce visual clutter and cognitive overload.